### PR TITLE
[Bugfix]: Audio wasn't working on firefox

### DIFF
--- a/src/audio/createElectricPianoOscillator.ts
+++ b/src/audio/createElectricPianoOscillator.ts
@@ -1,5 +1,8 @@
 import organWave from '/audio/waves/piano.wave.json';
 
+const organWaveReal = new Float32Array(organWave.real);
+const organWaveImag = new Float32Array(organWave.imag);
+
 const audioContext = new AudioContext();
 
 const setValueCurveAtTimeForOneMinute = (
@@ -34,7 +37,7 @@ export const createElectricPianoOscillator = (frequency: number) => {
 
   const oscillator = audioContext.createOscillator();
   oscillator.frequency.value = frequency;
-  oscillator.setPeriodicWave(audioContext.createPeriodicWave(organWave.real, organWave.imag));
+  oscillator.setPeriodicWave(audioContext.createPeriodicWave(organWaveReal, organWaveImag));
   oscillator.connect(tremoloNode);
 
   return oscillator;


### PR DESCRIPTION
I was getting the following error on firefox:

```
TypeError: "Argument 1 of BaseAudioContext.createPeriodicWave does not implement interface Float32Array."
```

So I made the real and imag arrays into Float32Arrays and it's now working!